### PR TITLE
Formatting the SARIF output bug fix

### DIFF
--- a/src/model/sarif_convertor.py
+++ b/src/model/sarif_convertor.py
@@ -174,7 +174,6 @@ class SarifConvertor:
             [
                 ("Type", finding_json.get("category", SARIF_PLACEHOLDER)),
                 ("Severity", severity_tag),
-                ("Title", finding_json.get("title", SARIF_PLACEHOLDER)),
                 ("CWE", extra_data.get("cwe", "")),
                 ("Fixed version", finding_json.get("fixed_version", "")),
                 ("Published date", finding_json.get("published_date", "")),
@@ -184,16 +183,17 @@ class SarifConvertor:
                 ("Confidence", extra_data.get("confidence", "")),
                 ("Likelihood", extra_data.get("likelihood", "")),
                 ("Remediation", extra_data.get("remediation", "")),
-            ]
+            ],
+            bold_labels=True,
         )
 
         message = message_header + message_body
 
         if owasp:
-            message.append(f"**OWASP:**\n{self._format_list_as_markdown(owasp)}")
+            message.append(f"**OWASP:** {self._format_list_as_markdown(owasp)}")
 
         if references:
-            message.append(f"**References:** \n{self._format_list_as_markdown(references)}")
+            message.append(f"**References:** {self._format_list_as_markdown(references)}")
 
         return "\n".join(message)
 
@@ -271,7 +271,8 @@ class SarifConvertor:
                 ("Start line", str(start_line) if start_line else ""),
                 ("End line", str(end_line) if end_line else ""),
                 ("Alert hash", finding_json.get("result_hash", SARIF_PLACEHOLDER)),
-            ]
+            ],
+            bold_labels=False,
         )
 
         message_text = "\n".join(message)
@@ -318,12 +319,13 @@ class SarifConvertor:
         return location
 
     @staticmethod
-    def _build_message_body(fields: list[tuple[str, str]]) -> list[str]:
+    def _build_message_body(fields: list[tuple[str, str]], bold_labels: bool) -> list[str]:
         """
         Build formatted parts from label-value pairs, skipping empty values.
 
         Args:
             fields: List of (label, value) tuples. Empty string values are skipped.
+            bold_labels: Boolean value for bold labels formatting.
 
         Returns:
             List of formatted non-empty strings.
@@ -332,7 +334,10 @@ class SarifConvertor:
         for label, value in fields:
             if not value:
                 continue
-            parts.append(f"**{label}:** {value}")
+            if bold_labels:
+                parts.append(f"**{label}:** {value}")
+            else:
+                parts.append(f"{label}: {value}")
 
         return parts
 

--- a/tests/model/test_sarif_convertor.py
+++ b/tests/model/test_sarif_convertor.py
@@ -191,7 +191,6 @@ def test_convert_to_sarif_rule_message_text_includes_all_fields():
     assert "**test-rule**" in help_text
     assert "**Type:** sast" in help_text
     assert "**Severity:** HIGH" in help_text
-    assert "**Title:** Test" in help_text
     assert "**CWE:** CWE-295" in help_text
     assert "**Fixed version:** 1.2.3" in help_text
     assert "**Published date:** 2026-01-01" in help_text
@@ -268,20 +267,20 @@ def test_convert_to_sarif_alert_message_includes_all_fields():
     actual = SarifConvertor().convert_to_sarif(findings)
 
     message = actual["runs"][0]["results"][0]["message"]["text"]
-    assert "**Artifact:** src/main.py" in message
-    assert "**Type:** sast" in message
-    assert "**Vulnerability:** test-rule" in message
-    assert "**Severity:** HIGH" in message
-    assert "**Message:** Test message" in message
-    assert "**Repository:** org/repo" in message
-    assert "**Reachable:** False" in message
-    assert "**Scan date:** 2026-02-08T15:16:40.219Z" in message
-    assert "**First seen:** 2025-09-17T12:46:48.271Z" in message
-    assert "**SCM file:** https://github.com/org/repo/blob/abc/src/main.py" in message
-    assert "**Installed version:** 1.0.0" in message
-    assert "**Start line:** 42" in message
-    assert "**End line:** 45" in message
-    assert "**Alert hash:** abc123" in message
+    assert "Artifact: src/main.py" in message
+    assert "Type: sast" in message
+    assert "Vulnerability: test-rule" in message
+    assert "Severity: HIGH" in message
+    assert "Message: Test message" in message
+    assert "Repository: org/repo" in message
+    assert "Reachable: False" in message
+    assert "Scan date: 2026-02-08T15:16:40.219Z" in message
+    assert "First seen: 2025-09-17T12:46:48.271Z" in message
+    assert "SCM file: https://github.com/org/repo/blob/abc/src/main.py" in message
+    assert "Installed version: 1.0.0" in message
+    assert "Start line: 42" in message
+    assert "End line: 45" in message
+    assert "Alert hash: abc123" in message
 
 
 def test_convert_to_sarif_alert_message_omits_empty_optional_fields():
@@ -301,14 +300,14 @@ def test_convert_to_sarif_alert_message_omits_empty_optional_fields():
     actual = SarifConvertor().convert_to_sarif(findings)
 
     message = actual["runs"][0]["results"][0]["message"]["text"]
-    assert "**Repository:**" not in message
-    assert "**Reachable:**" not in message
-    assert "**Scan date:**" not in message
-    assert "**First seen:**" not in message
-    assert "**SCM file:**" not in message
-    assert "**Installed version:**" not in message
-    assert "**Start line:**" not in message
-    assert "**End line:**" not in message
+    assert "Repository:" not in message
+    assert "Reachable:" not in message
+    assert "Scan date:" not in message
+    assert "First seen:" not in message
+    assert "SCM file:" not in message
+    assert "Installed version:" not in message
+    assert "Start line:" not in message
+    assert "End line:" not in message
 
 
 # _build_message_body
@@ -317,7 +316,7 @@ def test_convert_to_sarif_alert_message_omits_empty_optional_fields():
 def test_build_message_body_formats_with_bold():
     fields = [("Label", "value"), ("Empty", ""), ("Other", "data")]
 
-    actual = SarifConvertor._build_message_body(fields)
+    actual = SarifConvertor._build_message_body(fields, bold_labels=True)
 
     assert ["**Label:** value", "**Other:** data"] == actual
 
@@ -325,7 +324,7 @@ def test_build_message_body_formats_with_bold():
 def test_build_message_body_skips_empty_values():
     fields = [("First", ""), ("Second", "val"), ("Third", "")]
 
-    actual = SarifConvertor._build_message_body(fields)
+    actual = SarifConvertor._build_message_body(fields, bold_labels=True)
 
     assert ["**Second:** val"] == actual
 


### PR DESCRIPTION
<!-- What problem does it solve or what feature does it add? -->
## Overview
This pull request updates the SARIF converter to allow configurable label formatting in generated messages, enabling or disabling bold labels as appropriate for different message types. It also updates the relevant tests to match the new formatting and removes the "Title" field from rule messages.

<!-- Summarize the key changes for release notes. -->
## Release Notes
- Bug fix for correct SARIF output formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated message formatting to conditionally apply bold styling to labels.
  * Removed Title field from rule messages for cleaner output.
  * Changed OWASP and References sections to display on a single line instead of multi-line format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->