### PR TITLE
Adding hash for AquaSec CI scan.

### DIFF
--- a/.github/workflows/aquasec-night-scan.yml
+++ b/.github/workflows/aquasec-night-scan.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Fetch AquaSec Scan Results
         id: aquasec
-        uses: AbsaOSS/aquasec-scan-results@master
+        uses: AbsaOSS/aquasec-scan-results@06079bf026e447c12c72ba63586364d7ee0f3336
         with:
           aqua-key: ${{ secrets.AQUA_KEY }}
           aqua-secret: ${{ secrets.AQUA_SECRET }}


### PR DESCRIPTION
<!-- What problem does it solve or what feature does it add? -->
## Overview
This pull request updates the AquaSec scan workflow to improve reliability by pinning the action to a specific commit instead of using the `master` branch.

<!-- Summarize the key changes for release notes. -->
## Release Notes
- Adding hash for AquaSec CI scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned security scan action to a specific version for improved consistency and stability in the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->