### PR TITLE
docs: add detailed documentation for Branch Comparison and Night Scan modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ It supports two operational modes:
 This provides developers with immediate visibility into security vulnerabilities within their familiar
 GitHub workflow, eliminating the need to log in to the AquaSec platform.
 
+> For a high-level look at both modes see [Night Scan Mode](docs/night-scan-mode.md) and [Branch Comparison Mode](docs/branch-comparison-mode.md).
+
 ---
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It supports two operational modes:
 This provides developers with immediate visibility into security vulnerabilities within their familiar
 GitHub workflow, eliminating the need to log in to the AquaSec platform.
 
-> For a high-level look at both modes see [Night Scan Mode](docs/night-scan-mode.md) and [Branch Comparison Mode](docs/branch-comparison-mode.md).
+> For a detail look at both modes see [Night Scan Mode](docs/night-scan-mode.md) and [Branch Comparison Mode](docs/branch-comparison-mode.md).
 
 ---
 ## Prerequisites

--- a/docs/branch-comparison-mode.md
+++ b/docs/branch-comparison-mode.md
@@ -1,220 +1,149 @@
-
 # Branch Comparison Mode
-
-> An optional operational mode of the [AquaSec Scan Results](../README.md) action, enabled by
-> setting `dev-branch-comparison: 'true'`.
-
----
-
-## Table of Contents
-
-- [Overview](#overview)
-- [Flow](#flow)
-- [Inputs](#inputs)
-- [Output](#output)
-- [Example Workflow](#example-workflow)
-- [PR Comment Format](#pr-comment-format)
-- [Failure Behaviour](#failure-behaviour)
-
----
 
 ## Overview
 
-Branch Comparison Mode triggers a fresh AquaSec scan on the developer branch, fetches findings for
-both the dev branch and master, computes the delta, and writes a Markdown summary. The summary is
-surfaced as a step output so the caller workflow can post it as a PR comment.
+Branch Comparison Mode provides **shift-left security feedback directly in your pull requests**.
+Every time a PR is opened or updated, the action triggers a fresh AquaSec scan on the developer
+branch, compares the results against the master branch baseline, and posts a severity breakdown
+as a **PR comment**. Blocking the merge when new security findings are introduced.
 
-Typical trigger: **pull request workflow** (`opened`, `synchronize`, `reopened`).
-
-> **Prerequisite:** The workflow must run on a `pull_request` trigger so that the `GITHUB_HEAD_REF`
-> environment variable is set to the PR source branch name.
+> For setup instructions and workflow configuration, see the main [README](../README.md).
 
 ---
 
-## Flow
+## How It Works
 
 ```mermaid
-flowchart TB
-    subgraph GHA["☁️ GitHub Actions — Pull Request Trigger"]
-    end
+flowchart TD
+    A["🔀 PR Opened / Updated"] --> B["🔑 Authenticate with AquaSec API"]
+    B --> C["🚀 Trigger Dev Branch Scan"]
+    C --> D["⏳ Poll for Scan Completion"]
+    D --> E["📥 Fetch Dev Branch Findings"]
+    E --> F["📥 Fetch Master Branch Findings"]
+    F --> G["🔍 Compare & Deduplicate"]
+    G --> H["📝 Generate Markdown Summary"]
+    H --> I["💬 Post PR Comment"]
+    I --> J{New Findings?}
+    J -- Yes --> K["❌ Fail Workflow"]
+    J -- No --> L["✅ Pass"]
 
-    subgraph ACTION["⚙️ AquaSec Action"]
-        AUTH["Authenticate with AquaSec<br/>Verify credentials and obtain an access token"]
-        ST["Trigger Dev Branch Scan<br/>Start a fresh scan and wait for it to complete"]
-        FETCH_DEV["Fetch Dev Branch Findings<br/>Retrieve vulnerabilities discovered in the new scan"]
-        FETCH_MASTER["Fetch Master Branch Findings<br/>Retrieve current vulnerabilities from master"]
-        COMP["Compare Branch Findings<br/>Identify new and resolved vulnerabilities"]
-        MD["Generate Summary Report<br/>Write Markdown comparison to file"]
-
-        AUTH         --> ST
-        ST           --> FETCH_DEV
-        AUTH         --> FETCH_MASTER
-        FETCH_DEV    --> COMP
-        FETCH_MASTER --> COMP
-        COMP         --> MD
-    end
-
-    subgraph AQUASEC["🔌 AquaSec API"]
-        direction TB
-        A1["Trigger Scan Endpoint<br/>Start a new scan on the dev branch"]
-        A2["Check Scan Status Endpoint<br/>Poll until the scan completes"]
-        A3["Findings Endpoint<br/>Return vulnerability findings for a branch"]
-        A1 ~~~ A2 ~~~ A3
-    end
-
-    subgraph STEPOUT["📤 Action Output"]
-        direction TB
-        SUMMARY["Summary File Path<br/>Output location of the Markdown comparison report"]
-        EXIT{"Workflow Result<br/>Fails if new vulnerabilities are detected"}
-    end
-
-    subgraph PR["🔀 GitHub PR  (next steps)"]
-        direction TB
-        COMMENT["Post PR Comment<br/>Surface the security comparison on the pull request"]
-        CHECK["Status Check<br/>Blocks or allows the pull request to merge"]
-    end
-
-    GHA          -->|"trigger"| AUTH
-    ST          <-->  A1
-    ST          <-->  A2
-    FETCH_DEV   <-->|"dev branch findings"| A3
-    FETCH_MASTER<-->|"master branch findings"| A3
-    MD           --> SUMMARY
-    MD           --> EXIT
-    SUMMARY      --> COMMENT
-    EXIT         --> CHECK
+    style A fill:#4a6fa5,color:#fff,stroke:#3a5a8a
+    style B fill:#c8922a,color:#fff,stroke:#a87520
+    style C fill:#5b8db8,color:#fff,stroke:#4a7aa0
+    style D fill:#7b6ba8,color:#fff,stroke:#6a5a95
+    style E fill:#3d9e7a,color:#fff,stroke:#2e8068
+    style F fill:#3d9e7a,color:#fff,stroke:#2e8068
+    style G fill:#4a8a6a,color:#fff,stroke:#3a7055
+    style H fill:#b07040,color:#fff,stroke:#8a5530
+    style I fill:#4a6fa5,color:#fff,stroke:#3a5a8a
+    style J fill:#9a8a30,color:#fff,stroke:#7a6a20
+    style K fill:#b03a3a,color:#fff,stroke:#8a2a2a
+    style L fill:#3a8a50,color:#fff,stroke:#2a6a3a
 ```
 
----
+1. **PR Event Trigger** — The workflow runs automatically when a pull request is opened,
+   synchronized (new commits pushed), or reopened.
 
-## Inputs
+2. **Authentication** — The action authenticates with the AquaSec API using HMAC-signed
+   credentials to obtain a short-lived bearer token.
 
-| Name | Description | Required | Default |
-|------|-------------|----------|--------|
-| `aqua-key` | AquaSec API Key credential | Yes | — |
-| `aqua-secret` | AquaSec API Secret credential | Yes | — |
-| `group-id` | AquaSec Group ID for authentication | Yes | — |
-| `repository-id` | AquaSec Repository ID (UUID format) | Yes | — |
-| `verbose-logging` | Enable detailed logging | No | `false` |
-| `dev-branch-comparison` | Must be `true` to activate this mode | No | `false` |
+3. **Trigger Dev Branch Scan** — A fresh security scan is triggered on the PR's head branch
+   via the AquaSec API.
 
-| Implicit environment variable | Description |
-|-------------------------------|-------------|
-| `GITHUB_HEAD_REF` | PR source branch name — set automatically by GitHub on `pull_request` triggers |
+4. **Poll for Completion** — The action polls the AquaSec API at a set interval until the
+   scan completes, fails, or the timeout is exceeded.
 
-> For details on obtaining `group-id` and `repository-id`, see the
-> [Action Configuration](../README.md#action-configuration) section of the README.
+5. **Fetch Findings** — Once the dev branch scan completes, the action fetches findings for
+   both the **dev branch** (from the triggered scan) and the **master branch** (from the
+   latest baseline scan).
 
----
+6. **Compare & Deduplicate** — Findings unique to the dev branch are marked as **new**;
+   findings that no longer appear are marked as **reduced**.
 
-## Output
+7. **Generate Summary** — A Markdown summary is generated with a severity breakdown table
+   and detailed lists of new and reduced findings.
 
-| Name | Description | Example |
-|------|-------------|--------|
-| `comparison-summary-file` | Absolute path to the Markdown comparison summary | `/home/runner/work/repo/comparison_summary.md` |
+8. **Post PR Comment** — The summary is saved to a file and made available as an action
+   output. A subsequent workflow step posts (or updates) the comment on the PR.
 
-> The file is written **before** the action fails, so steps guarded with `if: always()` can still
-> read and post it even when new findings are detected.
+9. **Pass / Fail** — If any **new findings** are detected, the action fails. If no new
+   findings exist, the workflow passes.
 
 ---
 
-## Example Workflow
+## Benefits
 
-Create a workflow file (e.g., `.github/workflows/aquasec-branch-comparison.yml`) to run on pull
-requests:
-
-```yaml
-name: AquaSec Branch Comparison
-
-on:
-  pull_request:
-    types: [ opened, synchronize, reopened ]
-
-concurrency:
-  group: aquasec-branch-comparison-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
-permissions:
-  contents: read
-  pull-requests: write
-
-jobs:
-  branch-comparison:
-    name: AquaSec Branch Comparison
-    if: ${{ !github.event.pull_request.head.repo.fork }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Compare branches
-        id: aquasec
-        uses: AbsaOSS/aquasec-scan-results@v0.2.0
-        with:
-          aqua-key: ${{ secrets.AQUA_KEY }}
-          aqua-secret: ${{ secrets.AQUA_SECRET }}
-          group-id: ${{ secrets.AQUA_GROUP_ID }}
-          repository-id: ${{ secrets.AQUA_REPOSITORY_ID }}
-          dev-branch-comparison: 'true'
-
-      - name: Find existing PR comment
-        if: always() && steps.aquasec.outputs.comparison-summary-file != ''
-        uses: peter-evans/find-comment@v4
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: '<!-- aquasec-branch-comparison -->'
-
-      - name: Post or update PR comment
-        if: always() && steps.aquasec.outputs.comparison-summary-file != ''
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          edit-mode: replace
-          body-path: ${{ steps.aquasec.outputs.comparison-summary-file }}
-```
-
-> **Note:** The `Compare branches` step **fails the workflow** when new security findings are
-> detected in the developer branch. The PR comment steps use `if: always()` so the summary is
-> always posted, even when the comparison step fails.
+- **Shift-left security** — developers see security findings before code reaches master,
+  not day later in a nightly report
+- **Immediate PR feedback** — a severity breakdown table appears directly in the PR
+  conversation, visible to reviewers and authors alike
+- **Merge protection** — new vulnerabilities automatically block the PR, preventing
+  regressions from being merged
+- **Clear accountability** — each PR shows exactly which findings were introduced and
+  which were resolved, making it easy to track who fixed what
+- **No context switching** — developers stay in GitHub; no need to log in to the
+  AquaSec platform
 
 ---
 
-## PR Comment Format
+## Example PR Comment
 
-The generated Markdown summary posted as a PR comment looks like this:
+Below is a realistic example of the summary comment posted on a pull request:
 
-```markdown
-<!-- aquasec-branch-comparison -->
-## AquaSec Security Scan — Branch Comparison
-Master compared with branch: feature/my-branch
-
-|             | CRITICAL | HIGH | MEDIUM | LOW |
-|-------------|:--------:|:----:|:------:|:---:|
-| New (+)     |    1     |   2  |    0   |  3  |
-| Reduced (-) |    0     |   1  |    1   |  0  |
-
-### New Findings
-...
-
-### Reduced Findings
-...
-```
+> ### AquaSec Security Scan — Branch Comparison
+> 
+> Master compared with branch: **feature/add-new-api**
+>
+> #### Severity Breakdown
+>
+> | | CRITICAL | HIGH | MEDIUM | LOW |
+> |---|---|---|---|---|
+> | **New (+)** | 0 | 1 | 2 | 0 |
+> | **Reduced (-)** | 0 | 0 | 1 | 1 |
+>
+> #### New Findings
+>
+> - **[HIGH]** CVE-2026-4567 — SQL Injection in query builder (`src/db/query.py:42`)
+> - **[MEDIUM]** CVE-2026-7890 — Insecure default TLS version (`src/net/client.py:18`)
+> - **[MEDIUM]** CVE-2026-1122 — Missing input validation (`src/api/handler.py:105`)
+>
+> #### Reduced Findings
+>
+> - **[MEDIUM]** CVE-2025-3344 — Outdated cryptography library (`requirements.txt:8`)
+> - **[LOW]** CVE-2025-9911 — Informational header disclosure (`src/server.py:31`)
 
 ---
 
 ## Failure Behaviour
 
-| Condition | Exit code | Workflow check | PR merge (branch protection) |
-|-----------|:---------:|:--------------:|:-----------------------------:|
-| New findings detected | `1` (non-zero) | Fails | Blocked |
-| No new findings | `0` | Passes | Allowed |
+The action guarantees that **the PR comment is always posted**, even when new findings cause the workflow to fail.
+The summary is saved and the output is set before any failure is raised. Reviewers see the full analysis regardless
+of the check result.
 
-When new findings are detected the action emits a `::error::` annotation visible in the workflow
-log, then exits with code `1`. The comparison summary file is written before the failure so
-subsequent steps using `if: always()` can still post it as a PR comment.
+---
+
+## Inputs & Outputs
+
+### Required Inputs
+
+>| Input                   | Description                                  |
+>|-------------------------|----------------------------------------------|
+>| aqua-key                | AquaSec API Key credential                   |
+>| aqua-secret             | AquaSec API Secret credential                |
+>| group-id                | AquaSec Group ID for authentication          |
+>| repository-id           | AquaSec Repository ID (UUID format)          |
+>| dev-branch-comparison   | Must be set to 'true' to enable this mode    |
+
+### Output
+
+>| Output                    | Description                                      |
+>|---------------------------|--------------------------------------------------|
+>| comparison-summary-file   | Absolute path to the Markdown comparison summary |
+
+---
+
+## See Also
+
+- [Night Scan Mode](night-scan-mode.md) — nightly security scans uploaded to the GitHub
+  Security and quality tab
+- [README — Full Setup Guide](../README.md) — workflow configuration, credentials, and examples

--- a/docs/branch-comparison-mode.md
+++ b/docs/branch-comparison-mode.md
@@ -35,17 +35,16 @@ Typical trigger: **pull request workflow** (`opened`, `synchronize`, `reopened`)
 
 ```mermaid
 flowchart TB
-    subgraph GHA["☁️ GitHub Actions Workflow  —  pull_request trigger"]
-        TRG["PR event: opened · synchronize · reopened\nInputs: aqua-key · aqua-secret · group-id · repository-id · dev-branch-comparison: true\nImplicit env: GITHUB_HEAD_REF  (PR source branch)"]
+    subgraph GHA["☁️ GitHub Actions — Pull Request Trigger"]
     end
 
-    subgraph ACTION["⚙️ AquaSec Action  —  main.py"]
-        AUTH["Authenticator\nHMAC-SHA256  →  bearer token"]
-        ST["ScanTrigger\nPOST /scans/trigger  →  poll  →  scan_id"]
-        FETCH_DEV["ScanFetcher  (dev branch)\nGET /findings?scanIds={scan_id}"]
-        FETCH_MASTER["ScanFetcher  (master)\nGET /findings?repositoryIds={repo_id}"]
-        COMP["BranchComparator\nnew  =  dev keys  −  master keys\nreduced  =  master keys  −  dev keys"]
-        MD["Write  comparison_summary.md"]
+    subgraph ACTION["⚙️ AquaSec Action"]
+        AUTH["Authenticate with AquaSec<br/>Verify credentials and obtain an access token"]
+        ST["Trigger Dev Branch Scan<br/>Start a fresh scan and wait for it to complete"]
+        FETCH_DEV["Fetch Dev Branch Findings<br/>Retrieve vulnerabilities discovered in the new scan"]
+        FETCH_MASTER["Fetch Master Branch Findings<br/>Retrieve current vulnerabilities from master"]
+        COMP["Compare Branch Findings<br/>Identify new and resolved vulnerabilities"]
+        MD["Generate Summary Report<br/>Write Markdown comparison to file"]
 
         AUTH         --> ST
         ST           --> FETCH_DEV
@@ -56,26 +55,30 @@ flowchart TB
     end
 
     subgraph AQUASEC["🔌 AquaSec API"]
-        A1["POST /scans/trigger"]
-        A2["GET /repositories/{id}/branches  (poll)"] 
-        A3["GET /findings"]
+        direction TB
+        A1["Trigger Scan Endpoint<br/>Start a new scan on the dev branch"]
+        A2["Check Scan Status Endpoint<br/>Poll until the scan completes"]
+        A3["Findings Endpoint<br/>Return vulnerability findings for a branch"]
+        A1 ~~~ A2 ~~~ A3
     end
 
     subgraph STEPOUT["📤 Action Output"]
-        SUMMARY["comparison-summary-file  (absolute path)"]
-        EXIT{"exit code\nnon-zero = new findings\nzero = clean"}
+        direction TB
+        SUMMARY["Summary File Path<br/>Output location of the Markdown comparison report"]
+        EXIT{"Workflow Result<br/>Fails if new vulnerabilities are detected"}
     end
 
     subgraph PR["🔀 GitHub PR  (next steps)"]
-        COMMENT["PR Comment\ncreate-or-update-comment"]
-        CHECK["Required Status Check\nblocks / allows merge"]
+        direction TB
+        COMMENT["Post PR Comment<br/>Surface the security comparison on the pull request"]
+        CHECK["Status Check<br/>Blocks or allows the pull request to merge"]
     end
 
     GHA          -->|"trigger"| AUTH
     ST          <-->  A1
     ST          <-->  A2
-    FETCH_DEV   <-->|"dev findings JSON"| A3
-    FETCH_MASTER<-->|"master findings JSON"| A3
+    FETCH_DEV   <-->|"dev branch findings"| A3
+    FETCH_MASTER<-->|"master branch findings"| A3
     MD           --> SUMMARY
     MD           --> EXIT
     SUMMARY      --> COMMENT

--- a/docs/branch-comparison-mode.md
+++ b/docs/branch-comparison-mode.md
@@ -81,6 +81,10 @@ flowchart TD
   regressions from being merged
 - **Clear accountability** — each PR shows exactly which findings were introduced and
   which were resolved, making it easy to track who fixed what
+> **⚠️ Exception: 3rd party vulnerability between scans** — a new finding may occasionally
+> appear that was not introduced by the PR author. If a new CVE is published and matched to
+> an existing dependency between the last master night scan and this branch scan, it will be
+> flagged as a new finding even though the developer did not change that dependency.
 - **No context switching** — developers stay in GitHub; no need to log in to the
   AquaSec platform
 
@@ -124,21 +128,22 @@ of the check result.
 
 ## Inputs & Outputs
 
-### Required Inputs
+### Action Inputs
 
->| Input                   | Description                                  |
->|-------------------------|----------------------------------------------|
->| aqua-key                | AquaSec API Key credential                   |
->| aqua-secret             | AquaSec API Secret credential                |
->| group-id                | AquaSec Group ID for authentication          |
->| repository-id           | AquaSec Repository ID (UUID format)          |
->| dev-branch-comparison   | Must be set to 'true' to enable this mode    |
+| Input                   | Description                                  | Required |
+|-------------------------|----------------------------------------------|----------|
+| aqua-key                | AquaSec API Key credential                   | Yes      |
+| aqua-secret             | AquaSec API Secret credential                | Yes      |
+| group-id                | AquaSec Group ID for authentication          | Yes      |
+| repository-id           | AquaSec Repository ID (UUID format)          | Yes      |
+| dev-branch-comparison   | Must be set to 'true' to enable this mode    | Yes      |
+| verbose-logging         | Enable detailed logging                      | No       |
 
 ### Output
 
->| Output                    | Description                                      |
->|---------------------------|--------------------------------------------------|
->| comparison-summary-file   | Absolute path to the Markdown comparison summary |
+| Output                    | Description                                      |
+|---------------------------|--------------------------------------------------|
+| comparison-summary-file   | Absolute path to the Markdown comparison summary |
 
 ---
 

--- a/docs/branch-comparison-mode.md
+++ b/docs/branch-comparison-mode.md
@@ -1,0 +1,217 @@
+
+# Branch Comparison Mode
+
+> An optional operational mode of the [AquaSec Scan Results](../README.md) action, enabled by
+> setting `dev-branch-comparison: 'true'`.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Flow](#flow)
+- [Inputs](#inputs)
+- [Output](#output)
+- [Example Workflow](#example-workflow)
+- [PR Comment Format](#pr-comment-format)
+- [Failure Behaviour](#failure-behaviour)
+
+---
+
+## Overview
+
+Branch Comparison Mode triggers a fresh AquaSec scan on the developer branch, fetches findings for
+both the dev branch and master, computes the delta, and writes a Markdown summary. The summary is
+surfaced as a step output so the caller workflow can post it as a PR comment.
+
+Typical trigger: **pull request workflow** (`opened`, `synchronize`, `reopened`).
+
+> **Prerequisite:** The workflow must run on a `pull_request` trigger so that the `GITHUB_HEAD_REF`
+> environment variable is set to the PR source branch name.
+
+---
+
+## Flow
+
+```mermaid
+flowchart TB
+    subgraph GHA["☁️ GitHub Actions Workflow  —  pull_request trigger"]
+        TRG["PR event: opened · synchronize · reopened\nInputs: aqua-key · aqua-secret · group-id · repository-id · dev-branch-comparison: true\nImplicit env: GITHUB_HEAD_REF  (PR source branch)"]
+    end
+
+    subgraph ACTION["⚙️ AquaSec Action  —  main.py"]
+        AUTH["Authenticator\nHMAC-SHA256  →  bearer token"]
+        ST["ScanTrigger\nPOST /scans/trigger  →  poll  →  scan_id"]
+        FETCH_DEV["ScanFetcher  (dev branch)\nGET /findings?scanIds={scan_id}"]
+        FETCH_MASTER["ScanFetcher  (master)\nGET /findings?repositoryIds={repo_id}"]
+        COMP["BranchComparator\nnew  =  dev keys  −  master keys\nreduced  =  master keys  −  dev keys"]
+        MD["Write  comparison_summary.md"]
+
+        AUTH         --> ST
+        ST           --> FETCH_DEV
+        AUTH         --> FETCH_MASTER
+        FETCH_DEV    --> COMP
+        FETCH_MASTER --> COMP
+        COMP         --> MD
+    end
+
+    subgraph AQUASEC["🔌 AquaSec API"]
+        A1["POST /scans/trigger"]
+        A2["GET /repositories/{id}/branches  (poll)"] 
+        A3["GET /findings"]
+    end
+
+    subgraph STEPOUT["📤 Action Output"]
+        SUMMARY["comparison-summary-file  (absolute path)"]
+        EXIT{"exit code\nnon-zero = new findings\nzero = clean"}
+    end
+
+    subgraph PR["🔀 GitHub PR  (next steps)"]
+        COMMENT["PR Comment\ncreate-or-update-comment"]
+        CHECK["Required Status Check\nblocks / allows merge"]
+    end
+
+    GHA          -->|"trigger"| AUTH
+    ST          <-->  A1
+    ST          <-->  A2
+    FETCH_DEV   <-->|"dev findings JSON"| A3
+    FETCH_MASTER<-->|"master findings JSON"| A3
+    MD           --> SUMMARY
+    MD           --> EXIT
+    SUMMARY      --> COMMENT
+    EXIT         --> CHECK
+```
+
+---
+
+## Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|--------|
+| `aqua-key` | AquaSec API Key credential | Yes | — |
+| `aqua-secret` | AquaSec API Secret credential | Yes | — |
+| `group-id` | AquaSec Group ID for authentication | Yes | — |
+| `repository-id` | AquaSec Repository ID (UUID format) | Yes | — |
+| `verbose-logging` | Enable detailed logging | No | `false` |
+| `dev-branch-comparison` | Must be `true` to activate this mode | No | `false` |
+
+| Implicit environment variable | Description |
+|-------------------------------|-------------|
+| `GITHUB_HEAD_REF` | PR source branch name — set automatically by GitHub on `pull_request` triggers |
+
+> For details on obtaining `group-id` and `repository-id`, see the
+> [Action Configuration](../README.md#action-configuration) section of the README.
+
+---
+
+## Output
+
+| Name | Description | Example |
+|------|-------------|--------|
+| `comparison-summary-file` | Absolute path to the Markdown comparison summary | `/home/runner/work/repo/comparison_summary.md` |
+
+> The file is written **before** the action fails, so steps guarded with `if: always()` can still
+> read and post it even when new findings are detected.
+
+---
+
+## Example Workflow
+
+Create a workflow file (e.g., `.github/workflows/aquasec-branch-comparison.yml`) to run on pull
+requests:
+
+```yaml
+name: AquaSec Branch Comparison
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+concurrency:
+  group: aquasec-branch-comparison-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  branch-comparison:
+    name: AquaSec Branch Comparison
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Compare branches
+        id: aquasec
+        uses: AbsaOSS/aquasec-scan-results@v0.2.0
+        with:
+          aqua-key: ${{ secrets.AQUA_KEY }}
+          aqua-secret: ${{ secrets.AQUA_SECRET }}
+          group-id: ${{ secrets.AQUA_GROUP_ID }}
+          repository-id: ${{ secrets.AQUA_REPOSITORY_ID }}
+          dev-branch-comparison: 'true'
+
+      - name: Find existing PR comment
+        if: always() && steps.aquasec.outputs.comparison-summary-file != ''
+        uses: peter-evans/find-comment@v4
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- aquasec-branch-comparison -->'
+
+      - name: Post or update PR comment
+        if: always() && steps.aquasec.outputs.comparison-summary-file != ''
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body-path: ${{ steps.aquasec.outputs.comparison-summary-file }}
+```
+
+> **Note:** The `Compare branches` step **fails the workflow** when new security findings are
+> detected in the developer branch. The PR comment steps use `if: always()` so the summary is
+> always posted, even when the comparison step fails.
+
+---
+
+## PR Comment Format
+
+The generated Markdown summary posted as a PR comment looks like this:
+
+```markdown
+<!-- aquasec-branch-comparison -->
+## AquaSec Security Scan — Branch Comparison
+Master compared with branch: feature/my-branch
+
+|             | CRITICAL | HIGH | MEDIUM | LOW |
+|-------------|:--------:|:----:|:------:|:---:|
+| New (+)     |    1     |   2  |    0   |  3  |
+| Reduced (-) |    0     |   1  |    1   |  0  |
+
+### New Findings
+...
+
+### Reduced Findings
+...
+```
+
+---
+
+## Failure Behaviour
+
+| Condition | Exit code | Workflow check | PR merge (branch protection) |
+|-----------|:---------:|:--------------:|:-----------------------------:|
+| New findings detected | `1` (non-zero) | Fails | Blocked |
+| No new findings | `0` | Passes | Allowed |
+
+When new findings are detected the action emits a `::error::` annotation visible in the workflow
+log, then exits with code `1`. The comparison summary file is written before the failure so
+subsequent steps using `if: always()` can still post it as a PR comment.

--- a/docs/night-scan-mode.md
+++ b/docs/night-scan-mode.md
@@ -31,34 +31,36 @@ Typical trigger: **nightly scheduled workflow**.
 
 ```mermaid
 flowchart TB
-    subgraph GHA["☁️ GitHub Actions Workflow  (caller)"]
-        TRG["Scheduled cron / workflow_dispatch\nInputs: aqua-key · aqua-secret · group-id · repository-id"]
+    subgraph GHA["☁️ GitHub Actions — Nightly Schedule or Manual Trigger"]
     end
 
-    subgraph ACTION["⚙️ AquaSec Action  —  main.py"]
-        AUTH["Authenticator\nHMAC-SHA256  →  bearer token"]
-        FETCH["ScanFetcher\nGET /findings?repositoryIds={id}  (paginated)"]
-        CONV["SarifConvertor\nfindings JSON  →  SARIF 2.1.0"]
-        FILE["Write  aquasec_results.sarif"]
+    subgraph ACTION["⚙️ AquaSec Action"]
+        AUTH["Authenticate with AquaSec<br/>Verify credentials and obtain an access token"]
+        FETCH["Fetch Security Findings<br/>Retrieve all vulnerabilities for the repository"]
+        CONV["Convert to SARIF Format<br/>Transform results into a GitHub-compatible report"]
+        FILE["Save Report to File<br/>Write the SARIF file to disk"]
         AUTH --> FETCH --> CONV --> FILE
     end
 
     subgraph AQUASEC["🔌 AquaSec API"]
-        EP["GET /findings\n?repositoryIds={repo_id}"]
+        EP["Findings Endpoint<br/>Returns all scan findings for the repository"]
     end
 
     subgraph STEPOUT["📤 Action Output"]
-        SARIF_PATH["nightscan-sarif-file\n(absolute path)"]
+        SARIF_PATH["SARIF File Path<br/>Output location of the generated security report"]
     end
 
-    subgraph SEC["🛡️ GitHub Security Tab  (next step)"]
-        UPLOAD["github/codeql-action/upload-sarif\nCode scanning alerts"]
+    subgraph SEC["🛡️ GitHub Security Tab"]
+        direction TB
+        UPLOAD_STEP["Caller Workflow YAML Step<br/>Uses github/codeql-action/upload-sarif"]
+        SCANNING["Code Scanning Alerts<br/>Findings visible under Repository → Security"]
+        UPLOAD_STEP --> SCANNING
     end
 
     GHA          -->|"trigger"| AUTH
-    FETCH       <-->|"paginated findings JSON"| EP
+    FETCH       <-->|"security findings"| EP
     FILE         --> SARIF_PATH
-    SARIF_PATH   --> UPLOAD
+    SARIF_PATH   --> UPLOAD_STEP
 ```
 
 ---

--- a/docs/night-scan-mode.md
+++ b/docs/night-scan-mode.md
@@ -1,0 +1,156 @@
+
+# Night Scan Mode
+
+> The default operational mode of the [AquaSec Scan Results](../README.md) action.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Flow](#flow)
+- [Inputs](#inputs)
+- [Output](#output)
+- [Example Workflow](#example-workflow)
+- [GitHub Security Tab Integration](#github-security-tab-integration)
+
+---
+
+## Overview
+
+Night Scan Mode retrieves all security scan findings for a repository from the AquaSec API, converts
+them to [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) format, and
+writes the result to a file. The file path is surfaced as a step output so the caller workflow can
+upload it directly to GitHub's Code Scanning feature (Security tab).
+
+Typical trigger: **nightly scheduled workflow**.
+
+---
+
+## Flow
+
+```mermaid
+flowchart TB
+    subgraph GHA["☁️ GitHub Actions Workflow  (caller)"]
+        TRG["Scheduled cron / workflow_dispatch\nInputs: aqua-key · aqua-secret · group-id · repository-id"]
+    end
+
+    subgraph ACTION["⚙️ AquaSec Action  —  main.py"]
+        AUTH["Authenticator\nHMAC-SHA256  →  bearer token"]
+        FETCH["ScanFetcher\nGET /findings?repositoryIds={id}  (paginated)"]
+        CONV["SarifConvertor\nfindings JSON  →  SARIF 2.1.0"]
+        FILE["Write  aquasec_results.sarif"]
+        AUTH --> FETCH --> CONV --> FILE
+    end
+
+    subgraph AQUASEC["🔌 AquaSec API"]
+        EP["GET /findings\n?repositoryIds={repo_id}"]
+    end
+
+    subgraph STEPOUT["📤 Action Output"]
+        SARIF_PATH["nightscan-sarif-file\n(absolute path)"]
+    end
+
+    subgraph SEC["🛡️ GitHub Security Tab  (next step)"]
+        UPLOAD["github/codeql-action/upload-sarif\nCode scanning alerts"]
+    end
+
+    GHA          -->|"trigger"| AUTH
+    FETCH       <-->|"paginated findings JSON"| EP
+    FILE         --> SARIF_PATH
+    SARIF_PATH   --> UPLOAD
+```
+
+---
+
+## Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|--------|
+| `aqua-key` | AquaSec API Key credential | Yes | — |
+| `aqua-secret` | AquaSec API Secret credential | Yes | — |
+| `group-id` | AquaSec Group ID for authentication | Yes | — |
+| `repository-id` | AquaSec Repository ID (UUID format) | Yes | — |
+| `verbose-logging` | Enable detailed logging | No | `false` |
+| `dev-branch-comparison` | Must be `false` (or omitted) for this mode | No | `false` |
+
+> For details on obtaining `group-id` and `repository-id`, see the
+> [Action Configuration](../README.md#action-configuration) section of the README.
+
+---
+
+## Output
+
+| Name | Description | Example |
+|------|-------------|--------|
+| `nightscan-sarif-file` | Absolute path to the generated SARIF file | `/home/runner/work/repo/aquasec_results.sarif` |
+
+---
+
+## Example Workflow
+
+Create a workflow file (e.g., `.github/workflows/aquasec-night-scan.yml`) to run on a nightly
+schedule:
+
+```yaml
+name: AquaSec Night Scan
+
+on:
+  schedule:
+    - cron: '23 2 * * *'  # Runs at 02:23 UTC daily (modify as needed)
+  workflow_dispatch:
+
+concurrency:
+  group: aquasec-security-night-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  aquasec-night-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Fetch AquaSec Scan Results
+        id: aquasec
+        uses: AbsaOSS/aquasec-scan-results@v0.2.0
+        with:
+          aqua-key: ${{ secrets.AQUA_KEY }}
+          aqua-secret: ${{ secrets.AQUA_SECRET }}
+          group-id: ${{ secrets.AQUA_GROUP_ID }}
+          repository-id: ${{ secrets.AQUA_REPOSITORY_ID }}
+          verbose-logging: 'false'
+
+      - name: Upload Scan Results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.aquasec.outputs.nightscan-sarif-file }}
+          category: aquasec
+```
+
+---
+
+## GitHub Security Tab Integration
+
+After the SARIF file is uploaded with `github/codeql-action/upload-sarif`, findings appear under:
+
+**Repository → Security → Code scanning alerts**
+
+Each alert displays:
+
+- Severity level
+- Rule ID
+- File location
+- Remediation guidance

--- a/docs/night-scan-mode.md
+++ b/docs/night-scan-mode.md
@@ -66,54 +66,55 @@ After a successful Night Scan run, findings appear in **Security and quality →
 
 #### Security Alert
 
->| Field                | Example Value                                              |
->|----------------------|------------------------------------------------------------|
->| **Title**            | axios: Server-Side Request Forgery via redirect handling   |
->| **Alert hash**       | c3d9ee12f1bb52a9e08977c3e5108900                           |
->| **Artifact**         | backend/package.json                                       |
->| **Type**             | vulnerabilities                                            |
->| **Vulnerability**    | CVE-2026-18234                                             |
->| **Severity**         | HIGH                                                       |
->| **Repository**       | my-org/my-repo                                             |
->| **Reachable**        | True                                                       |
->| **Scan date**        | 2026-04-09T02:24:10.000Z                                   |
->| **First seen**       | 2026-03-01T08:00:00.000Z                                   |
->| **SCM file**         | Link to the exact file and commit in GitHub                |
->| **Installed version**| 1.6.5                                                      |
->| **Start / End line** | 42 / 42                                                    |
->| **Message**          | Full description of the vulnerability                      |
+| Field                | Example Value                                              |
+|----------------------|------------------------------------------------------------|
+| **Title**            | axios: Server-Side Request Forgery via redirect handling   |
+| **Alert hash**       | c3d9ee12f1bb52a9e08977c3e5108900                           |
+| **Artifact**         | backend/package.json                                       |
+| **Type**             | vulnerabilities                                            |
+| **Vulnerability**    | CVE-2026-18234                                             |
+| **Severity**         | HIGH                                                       |
+| **Repository**       | my-org/my-repo                                             |
+| **Reachable**        | True                                                       |
+| **Scan date**        | 2026-04-09T02:24:10.000Z                                   |
+| **First seen**       | 2026-03-01T08:00:00.000Z                                   |
+| **SCM file**         | Link to the exact file and commit in GitHub                |
+| **Installed version**| 1.6.5                                                      |
+| **Start / End line** | 42 / 42                                                    |
+| **Message**          | Full description of the vulnerability                      |
 
 #### Security Rule
 
 Each alert is also associated with a security rule that describes **why** the finding was flagged.
 
->| Field            | Example Value                               |
->|------------------|---------------------------------------------|
->| **Rule ID**      | CVE-2026-18234                              |
->| **Category**     | Dependency Vulnerability                    |
->| **CWE**          | CWE-918: Server-Side Request Forgery        |
->| **OWASP**        | A10:2021 – Server-Side Request Forgery      |
->| **Remediation**  | Upgrade axios to version 1.7.0 or later     |
->| **References**   | Link to NVD advisory and upstream fix       |
+| Field            | Example Value                               |
+|------------------|---------------------------------------------|
+| **Rule ID**      | CVE-2026-18234                              |
+| **Category**     | Dependency Vulnerability                    |
+| **CWE**          | CWE-918: Server-Side Request Forgery        |
+| **OWASP**        | A10:2021 – Server-Side Request Forgery      |
+| **Remediation**  | Upgrade axios to version 1.7.0 or later     |
+| **References**   | Link to NVD advisory and upstream fix       |
 
 ---
 
 ## Inputs & Outputs
 
-### Required Inputs
+### Action Inputs
 
->| Input             | Description                         |
->|-------------------|-------------------------------------|
->| aqua-key          | AquaSec API Key credential          |
->| aqua-secret       | AquaSec API Secret credential       |
->| group-id          | AquaSec Group ID for authentication |
->| repository-id     | AquaSec Repository ID (UUID format) |
+| Input             | Description                         | Required |
+|-------------------|-------------------------------------|----------|
+| aqua-key          | AquaSec API Key credential          | Yes      |
+| aqua-secret       | AquaSec API Secret credential       | Yes      |
+| group-id          | AquaSec Group ID for authentication | Yes      |
+| repository-id     | AquaSec Repository ID (UUID format) | Yes      |
+| verbose-logging   | Enable detailed logging             | No       |
 
 ### Output
 
->| Output                   | Description                                |
->|--------------------------|--------------------------------------------|
->| nightscan-sarif-file     | Absolute path to the generated SARIF file  |
+| Output                   | Description                                |
+|--------------------------|--------------------------------------------|
+| nightscan-sarif-file     | Absolute path to the generated SARIF file  |
 
 The SARIF file is then passed to the `github/codeql-action/upload-sarif` action for upload
 to the Security and quality tab.

--- a/docs/night-scan-mode.md
+++ b/docs/night-scan-mode.md
@@ -1,158 +1,127 @@
-
 # Night Scan Mode
-
-> The default operational mode of the [AquaSec Scan Results](../README.md) action.
-
----
-
-## Table of Contents
-
-- [Overview](#overview)
-- [Flow](#flow)
-- [Inputs](#inputs)
-- [Output](#output)
-- [Example Workflow](#example-workflow)
-- [GitHub Security Tab Integration](#github-security-tab-integration)
-
----
 
 ## Overview
 
-Night Scan Mode retrieves all security scan findings for a repository from the AquaSec API, converts
-them to [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) format, and
-writes the result to a file. The file path is surfaced as a step output so the caller workflow can
-upload it directly to GitHub's Code Scanning feature (Security tab).
+Night Scan Mode provides **continuous, automated security monitoring** for your repository by **AquaSec**.
+It is supposed to run on a nightly schedule (or any cron-based trigger), retrieves the latest security scan
+findings from AquaSec, converts them to the industry-standard
+[SARIF](https://sarifweb.azurewebsites.net/) format, and uploads them to
+the **GitHub Security and quality tab**. This gives your team a daily security posture snapshot without
+any manual effort.
 
-Typical trigger: **nightly scheduled workflow**.
+> For setup instructions and workflow configuration, see the main [README](../README.md).
 
 ---
 
-## Flow
+## How It Works
 
 ```mermaid
-flowchart TB
-    subgraph GHA["☁️ GitHub Actions — Nightly Schedule or Manual Trigger"]
-    end
+flowchart LR
+    A["⏰ Nightly Schedule\n(cron trigger)"] --> B["🔑 Authenticate\nwith AquaSec API"]
+    B --> C["📥 Fetch Scan\nFindings"]
+    C --> D["🔄 Convert to\nSARIF Format"]
+    D --> E["📤 Upload to GitHub\nSecurity Tab"]
 
-    subgraph ACTION["⚙️ AquaSec Action"]
-        AUTH["Authenticate with AquaSec<br/>Verify credentials and obtain an access token"]
-        FETCH["Fetch Security Findings<br/>Retrieve all vulnerabilities for the repository"]
-        CONV["Convert to SARIF Format<br/>Transform results into a GitHub-compatible report"]
-        FILE["Save Report to File<br/>Write the SARIF file to disk"]
-        AUTH --> FETCH --> CONV --> FILE
-    end
-
-    subgraph AQUASEC["🔌 AquaSec API"]
-        EP["Findings Endpoint<br/>Returns all scan findings for the repository"]
-    end
-
-    subgraph STEPOUT["📤 Action Output"]
-        SARIF_PATH["SARIF File Path<br/>Output location of the generated security report"]
-    end
-
-    subgraph SEC["🛡️ GitHub Security Tab"]
-        direction TB
-        UPLOAD_STEP["Caller Workflow YAML Step<br/>Uses github/codeql-action/upload-sarif"]
-        SCANNING["Code Scanning Alerts<br/>Findings visible under Repository → Security"]
-        UPLOAD_STEP --> SCANNING
-    end
-
-    GHA          -->|"trigger"| AUTH
-    FETCH       <-->|"security findings"| EP
-    FILE         --> SARIF_PATH
-    SARIF_PATH   --> UPLOAD_STEP
+    style A fill:#2e5090,color:#fff,stroke:#1e3a70
+    style B fill:#b07a1e,color:#fff,stroke:#8a5e10
+    style C fill:#2a7a6a,color:#fff,stroke:#1a5a4a
+    style D fill:#5a3d8a,color:#fff,stroke:#3a1d6a
+    style E fill:#2a7a40,color:#fff,stroke:#1a5a28
 ```
 
----
+1. **Scheduled Trigger** — A GitHub Actions cron schedule triggers the workflow automatically
+   (e.g., every night at 02:23 UTC). No developer action is required.
 
-## Inputs
+2. **Authentication** — The action authenticates with the AquaSec API using HMAC-signed
+   credentials (AquaSec API key, secret, and group ID) to obtain a short-lived bearer token.
 
-| Name | Description | Required | Default |
-|------|-------------|----------|--------|
-| `aqua-key` | AquaSec API Key credential | Yes | — |
-| `aqua-secret` | AquaSec API Secret credential | Yes | — |
-| `group-id` | AquaSec Group ID for authentication | Yes | — |
-| `repository-id` | AquaSec Repository ID (UUID format) | Yes | — |
-| `verbose-logging` | Enable detailed logging | No | `false` |
-| `dev-branch-comparison` | Must be `false` (or omitted) for this mode | No | `false` |
+3. **Fetch Findings** — Using the repository ID, the action retrieves all security findings
+   from the latest AquaSec scan. Results are fetched page by page to handle repositories
+   with large numbers of findings.
 
-> For details on obtaining `group-id` and `repository-id`, see the
-> [Action Configuration](../README.md#action-configuration) section of the README.
+4. **SARIF Conversion** — Each finding is mapped to a SARIF 2.1.0 rule and result, preserving
+   severity levels (Critical, High, Medium, Low), affected file locations, remediation guidance,
+   CWE references, and OWASP classifications.
 
----
-
-## Output
-
-| Name | Description | Example |
-|------|-------------|--------|
-| `nightscan-sarif-file` | Absolute path to the generated SARIF file | `/home/runner/work/repo/aquasec_results.sarif` |
+5. **Upload to GitHub** — The generated SARIF file is uploaded to GitHub's Code Scanning feature,
+   making findings visible directly in the **Security tab** of the repository.
 
 ---
 
-## Example Workflow
+## Benefits
 
-Create a workflow file (e.g., `.github/workflows/aquasec-night-scan.yml`) to run on a nightly
-schedule:
-
-```yaml
-name: AquaSec Night Scan
-
-on:
-  schedule:
-    - cron: '23 2 * * *'  # Runs at 02:23 UTC daily (modify as needed)
-  workflow_dispatch:
-
-concurrency:
-  group: aquasec-security-night-scan-${{ github.ref }}
-  cancel-in-progress: true
-
-permissions:
-  contents: read
-  security-events: write
-
-jobs:
-  aquasec-night-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-
-      - name: Fetch AquaSec Scan Results
-        id: aquasec
-        uses: AbsaOSS/aquasec-scan-results@v0.2.0
-        with:
-          aqua-key: ${{ secrets.AQUA_KEY }}
-          aqua-secret: ${{ secrets.AQUA_SECRET }}
-          group-id: ${{ secrets.AQUA_GROUP_ID }}
-          repository-id: ${{ secrets.AQUA_REPOSITORY_ID }}
-          verbose-logging: 'false'
-
-      - name: Upload Scan Results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: ${{ steps.aquasec.outputs.nightscan-sarif-file }}
-          category: aquasec
-```
+- **Zero manual effort** — scans run on autopilot every night
+- **Security tab integration** — findings appear alongside other code scanning alerts in GitHub
+- **Standard format** — SARIF is supported by GitHub, VS Code, and many other tools, making it
+  easy to integrate into existing security workflows
+- **Rich finding details** — each alert includes all the important information that AquaSec provides
+- **Historical tracking** — GitHub retains scan history, allowing teams to track security posture
+  over time and measure improvement
 
 ---
 
-## GitHub Security Tab Integration
+## What You See in GitHub
 
-After the SARIF file is uploaded with `github/codeql-action/upload-sarif`, findings appear under:
+After a successful Night Scan run, findings appear in **Security and quality → Code scanning alerts**.
 
-**Repository → Security → Code scanning alerts**
+#### Security Alert
 
-Each alert displays:
+>| Field                | Example Value                                              |
+>|----------------------|------------------------------------------------------------|
+>| **Title**            | axios: Server-Side Request Forgery via redirect handling   |
+>| **Alert hash**       | c3d9ee12f1bb52a9e08977c3e5108900                           |
+>| **Artifact**         | backend/package.json                                       |
+>| **Type**             | vulnerabilities                                            |
+>| **Vulnerability**    | CVE-2026-18234                                             |
+>| **Severity**         | HIGH                                                       |
+>| **Repository**       | my-org/my-repo                                             |
+>| **Reachable**        | True                                                       |
+>| **Scan date**        | 2026-04-09T02:24:10.000Z                                   |
+>| **First seen**       | 2026-03-01T08:00:00.000Z                                   |
+>| **SCM file**         | Link to the exact file and commit in GitHub                |
+>| **Installed version**| 1.6.5                                                      |
+>| **Start / End line** | 42 / 42                                                    |
+>| **Message**          | Full description of the vulnerability                      |
 
-- Severity level
-- Rule ID
-- File location
-- Remediation guidance
+#### Security Rule
+
+Each alert is also associated with a security rule that describes **why** the finding was flagged.
+
+>| Field            | Example Value                               |
+>|------------------|---------------------------------------------|
+>| **Rule ID**      | CVE-2026-18234                              |
+>| **Category**     | Dependency Vulnerability                    |
+>| **CWE**          | CWE-918: Server-Side Request Forgery        |
+>| **OWASP**        | A10:2021 – Server-Side Request Forgery      |
+>| **Remediation**  | Upgrade axios to version 1.7.0 or later     |
+>| **References**   | Link to NVD advisory and upstream fix       |
+
+---
+
+## Inputs & Outputs
+
+### Required Inputs
+
+>| Input             | Description                         |
+>|-------------------|-------------------------------------|
+>| aqua-key          | AquaSec API Key credential          |
+>| aqua-secret       | AquaSec API Secret credential       |
+>| group-id          | AquaSec Group ID for authentication |
+>| repository-id     | AquaSec Repository ID (UUID format) |
+
+### Output
+
+>| Output                   | Description                                |
+>|--------------------------|--------------------------------------------|
+>| nightscan-sarif-file     | Absolute path to the generated SARIF file  |
+
+The SARIF file is then passed to the `github/codeql-action/upload-sarif` action for upload
+to the Security and quality tab.
+
+---
+
+## See Also
+
+- [Branch Comparison Mode](branch-comparison-mode.md) — PR-level security checks that compare
+  findings between your branch and master
+- [README — Full Setup Guide](../README.md) — workflow configuration, credentials, and examples


### PR DESCRIPTION
## Overview

Created `docs/night-scan-mode.md` and `docs/branch-comparison-mode.md`.

Each document includes:
- Titled sections with a Table of Contents
- Mermaid block schema (`subgraph`-based) replacing the old ASCII art, visually separating the
  architectural layers (caller workflow, action internals, AquaSec API, outputs, and GitHub
  integration)
- Inputs and outputs reference tables synced with `README.md`
- Full copy-paste example workflow synced with `README.md`
- Mode-specific sections (GitHub Security Tab Integration / PR Comment Format / Failure Behaviour)

## Release Notes
- Docs: rewrote `docs/night-scan-mode.md` as structured Markdown
- Docs: rewrote `docs/branch-comparison-mode.md` as structured Markdown

Closes #93 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added docs for a Branch Comparison Mode: PR-triggered run compares dev vs baseline, classifies findings as new/reduced, writes a Markdown summary, exposes an output path, and posts/updates a PR comment (comment is posted even if the run fails).
  * Added docs for a Night Scan Mode: scheduled nightly run aggregates findings, converts to SARIF, exposes the SARIF file path for upload, and describes resulting GitHub security alerts.
  * README updated to link both new docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->